### PR TITLE
Fix: Nimble Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.so
 *.dylib
 *.out
+textalot
 
 # === Nim build cache ===
 # Directory created by the Nim compiler for intermediate files
@@ -24,6 +25,8 @@ obj/
 # === Nimble files ===
 # Lock file created by Nimble (can be regenerated)
 *.nimble.lock
+nimbledeps/
+deps/
 
 # === Logs / temporary files ===
 # General temporary or log files

--- a/textalot.nimble
+++ b/textalot.nimble
@@ -4,5 +4,4 @@ author        = "Eray Zesen <erayzesen@gmail.com>"
 description   = "A High-Performance Terminal I/O & TUI Engine written in Nim"
 license       = "MIT"
 srcDir        = "" 
-bin           = @[]
-requires      = @[]
+bin           = @["textalot"]


### PR DESCRIPTION
A small handful of basic fixes:

1. By not setting bin or requires to non-empty values, nimble and atlas (an alternative build system) would fail to compile your code.
2. Added a few common things to your .gitignore file so that others don’t pollute the repository when they contribute.

Congrats on releasing a new library.